### PR TITLE
Add R scripts that can run the same code as the `qmd` notebooks

### DIFF
--- a/ecr-parser/01-interacting-with-the-apis.qmd
+++ b/ecr-parser/01-interacting-with-the-apis.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Convert to FHIR"
+engine: knitr
 ---
 
 ## Spining up the services

--- a/ecr-parser/03-convert-to-flat-file.qmd
+++ b/ecr-parser/03-convert-to-flat-file.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Convert to Flat File"
+engine: knitr
 ---
 
 ## Spining up the services

--- a/ecr-parser/data/fhir-conversion/eICR_TC-DeDup1_Lab_Order-bundle.json
+++ b/ecr-parser/data/fhir-conversion/eICR_TC-DeDup1_Lab_Order-bundle.json
@@ -251,7 +251,7 @@
               }
             ],
             "subject": {
-              "reference": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+              "reference": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
             },
             "encounter": {
               "reference": "Encounter/baa7c66d-7ea1-0d5d-83c8-140971f11b36"
@@ -292,7 +292,7 @@
               "end": "2019-02-10"
             },
             "subject": {
-              "reference": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+              "reference": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
             },
             "location": [
               {
@@ -623,10 +623,10 @@
           }
         },
         {
-          "fullUrl": "urn:uuid:9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e",
+          "fullUrl": "urn:uuid:62879de1-0d7f-4365-bc32-1c6115c68b95",
           "resource": {
             "resourceType": "Patient",
-            "id": "9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e",
+            "id": "62879de1-0d7f-4365-bc32-1c6115c68b95",
             "meta": {
               "profile": [
                 "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
@@ -722,7 +722,7 @@
           },
           "request": {
             "method": "PUT",
-            "url": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+            "url": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
           }
         },
         {
@@ -730,7 +730,7 @@
           "resource": {
             "resourceType": "CareTeam",
             "subject": {
-              "reference": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+              "reference": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
             },
             "meta": {
               "source": [
@@ -746,7 +746,7 @@
             "status": "unknown",
             "intent": "proposal",
             "subject": {
-              "reference": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+              "reference": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
             },
             "meta": {
               "source": [
@@ -803,7 +803,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/9e4eec0d-b8cc-40a0-bd63-12a35b03ca1e"
+              "reference": "Patient/62879de1-0d7f-4365-bc32-1c6115c68b95"
             }
           },
           "request": {

--- a/ecr-parser/data/fhir-conversion/eICR_TC-DeDup2_Lab_Result-bundle.json
+++ b/ecr-parser/data/fhir-conversion/eICR_TC-DeDup2_Lab_Result-bundle.json
@@ -256,7 +256,7 @@
               }
             ],
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             },
             "relatesTo": [
               {
@@ -311,7 +311,7 @@
               "end": "2019-02-10"
             },
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             },
             "location": [
               {
@@ -646,10 +646,10 @@
           }
         },
         {
-          "fullUrl": "urn:uuid:495dbd2b-7a26-4f10-b0a7-31ff9cb80897",
+          "fullUrl": "urn:uuid:ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8",
           "resource": {
             "resourceType": "Patient",
-            "id": "495dbd2b-7a26-4f10-b0a7-31ff9cb80897",
+            "id": "ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8",
             "meta": {
               "profile": [
                 "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
@@ -745,7 +745,7 @@
           },
           "request": {
             "method": "PUT",
-            "url": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+            "url": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
           }
         },
         {
@@ -753,7 +753,7 @@
           "resource": {
             "resourceType": "CareTeam",
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             },
             "meta": {
               "source": [
@@ -769,7 +769,7 @@
             "status": "unknown",
             "intent": "proposal",
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             },
             "meta": {
               "source": [
@@ -804,7 +804,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             },
             "result": [
               {
@@ -871,7 +871,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             }
           },
           "request": {
@@ -938,7 +938,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/495dbd2b-7a26-4f10-b0a7-31ff9cb80897"
+              "reference": "Patient/ae05f86d-ba59-47ce-a75e-4c1a9b0baaa8"
             }
           },
           "request": {

--- a/ecr-parser/data/fhir-conversion/eICR_TC-Routing_VPD-bundle.json
+++ b/ecr-parser/data/fhir-conversion/eICR_TC-Routing_VPD-bundle.json
@@ -256,7 +256,7 @@
               }
             ],
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             },
             "relatesTo": [
               {
@@ -311,7 +311,7 @@
               "end": "2019-02-10"
             },
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             },
             "location": [
               {
@@ -646,10 +646,10 @@
           }
         },
         {
-          "fullUrl": "urn:uuid:4cba600a-d8cb-4ea5-a80d-5228b54a5cd0",
+          "fullUrl": "urn:uuid:8a3eaecd-9fee-40f3-809f-35df8b2d385d",
           "resource": {
             "resourceType": "Patient",
-            "id": "4cba600a-d8cb-4ea5-a80d-5228b54a5cd0",
+            "id": "8a3eaecd-9fee-40f3-809f-35df8b2d385d",
             "meta": {
               "profile": [
                 "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
@@ -745,7 +745,7 @@
           },
           "request": {
             "method": "PUT",
-            "url": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+            "url": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
           }
         },
         {
@@ -753,7 +753,7 @@
           "resource": {
             "resourceType": "CareTeam",
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             },
             "meta": {
               "source": [
@@ -769,7 +769,7 @@
             "status": "unknown",
             "intent": "proposal",
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             },
             "meta": {
               "source": [
@@ -804,7 +804,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             },
             "result": [
               {
@@ -871,7 +871,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             }
           },
           "request": {
@@ -938,7 +938,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/4cba600a-d8cb-4ea5-a80d-5228b54a5cd0"
+              "reference": "Patient/8a3eaecd-9fee-40f3-809f-35df8b2d385d"
             }
           },
           "request": {

--- a/ecr-parser/data/fhir-conversion/eICR_TC-eCR-Routing_STI-bundle.json
+++ b/ecr-parser/data/fhir-conversion/eICR_TC-eCR-Routing_STI-bundle.json
@@ -254,7 +254,7 @@
               }
             ],
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             },
             "encounter": {
               "reference": "Encounter/c20ce0ff-081b-4f7e-cf12-7b47ccd6b304"
@@ -295,7 +295,7 @@
               "end": "2019-02-10"
             },
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             },
             "location": [
               {
@@ -626,10 +626,10 @@
           }
         },
         {
-          "fullUrl": "urn:uuid:c91f2406-77ee-4632-8009-dd4f0e86a43b",
+          "fullUrl": "urn:uuid:a58ff11e-8da8-4bd7-9c7b-460f0347a3f4",
           "resource": {
             "resourceType": "Patient",
-            "id": "c91f2406-77ee-4632-8009-dd4f0e86a43b",
+            "id": "a58ff11e-8da8-4bd7-9c7b-460f0347a3f4",
             "meta": {
               "profile": [
                 "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
@@ -731,7 +731,7 @@
           },
           "request": {
             "method": "PUT",
-            "url": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+            "url": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
           }
         },
         {
@@ -739,7 +739,7 @@
           "resource": {
             "resourceType": "CareTeam",
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             },
             "meta": {
               "source": [
@@ -755,7 +755,7 @@
             "status": "unknown",
             "intent": "proposal",
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             },
             "meta": {
               "source": [
@@ -794,7 +794,7 @@
               "end": "2016-01-04"
             },
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             },
             "result": [
               {
@@ -862,7 +862,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             }
           },
           "request": {
@@ -929,7 +929,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             }
           },
           "request": {
@@ -985,7 +985,7 @@
               ]
             },
             "subject": {
-              "reference": "Patient/c91f2406-77ee-4632-8009-dd4f0e86a43b"
+              "reference": "Patient/a58ff11e-8da8-4bd7-9c7b-460f0347a3f4"
             }
           },
           "request": {

--- a/ecr-parser/scripts/01-convert-to-fhir.R
+++ b/ecr-parser/scripts/01-convert-to-fhir.R
@@ -1,0 +1,131 @@
+library(renv)
+renv::load()
+
+library(fs)
+library(httr2)
+library(jsonlite)
+library(tidyverse)
+
+# urls for the fhir converter service
+fhir_converter <- "http://localhost:8082"
+health_check <- str_glue("{fhir_converter}/")
+convert_to_fhir <- str_glue("{fhir_converter}/convert-to-fhir")
+
+# check the health of the fhir converter
+check_health <- function(endpoint_url) {
+  resp <- request(endpoint_url) |>
+    req_perform() |>
+    resp_body_json()
+  
+  if (resp$status == "OK") {
+    print("FHIR Converter is up and running.")
+  } else {
+    print("FHIR Converter is not running.")
+  }
+}
+
+check_health(health_check)
+
+# define directories
+# go up one level from the current script location
+ecr_data_directory <- path("data", "eicr-and-rr")
+fhir_bundle_directory <- path("data", "fhir-conversion")
+
+# function to read and collapse xml content into a single string
+read_and_collapse_xml <- function(file_path) {
+  print(str_glue("Reading file: {file_path}"))
+  xml_content <- readLines(file_path, warn = FALSE)
+  paste(xml_content, collapse = "\n")
+}
+
+# function to create a json payload
+create_json_payload <- function(eicr_content, rr_content, input_type = "ecr", root_template = "EICR") {
+  list(
+    input_data = eicr_content,
+    input_type = input_type,
+    root_template = root_template,
+    rr_data = rr_content
+  )
+}
+
+# function to send post request to the api
+send_post_request <- function(api_url, data) {
+  print("Sending request with data...")
+
+  response <- request(api_url) |>
+    req_body_json(data) |>
+    req_perform()
+
+  status <- resp_status(response)
+  print(str_glue("Response status: {status}"))
+
+  return(response)
+}
+
+# function to save json response to a file
+save_json_response <- function(response, file_id, output_dir) {
+  json_response <- resp_body_json(response)
+  json_file_path <- path(output_dir, str_glue("{file_id}-bundle.json"))
+  write_json(json_response, json_file_path, pretty = TRUE, auto_unbox = TRUE)
+
+  return(json_file_path)
+}
+
+# function to generate the rr file path based on the eicr file path
+get_rr_file_path <- function(eicr_file_path) {
+  file_name <- path_file(eicr_file_path)
+
+  if (str_detect(file_name, "_eICR")) {
+    rr_file_name <- str_replace(file_name, "_eICR", "_RR")
+  } else if (str_detect(file_name, "_eicr")) {
+    rr_file_name <- str_replace(file_name, "_eicr", "_RR")
+  }
+
+  return(path(path_dir(eicr_file_path), rr_file_name))
+}
+
+# function to process eicr files and send them to the fhir converter
+process_files <- function(data_dir, output_dir, api_url) {
+  print("Starting file processing...")
+  file_list <- dir_ls(data_dir, glob = "*_eicr.xml|*_eICR.xml")
+
+  for (eicr_file_path in file_list) {
+    print(str_glue("Processing file: {eicr_file_path}"))
+    rr_file_path <- get_rr_file_path(eicr_file_path)
+    print(str_glue("Corresponding RR file: {rr_file_path}"))
+
+    if (!file_exists(rr_file_path)) {
+      print(str_glue("RR file does not exist for: {eicr_file_path}"))
+      next
+    }
+
+    eicr_content <- read_and_collapse_xml(eicr_file_path)
+    rr_content <- read_and_collapse_xml(rr_file_path)
+
+    file_id <- str_split(path_file(eicr_file_path), "_CDA_eICR|_eICR|_eicr")[[1]][[1]]
+    print(str_glue("File ID: {file_id}"))
+
+    data <- create_json_payload(
+      eicr_content = eicr_content, 
+      rr_content = rr_content)
+
+    tryCatch({
+      response <- send_post_request(api_url, data)
+      
+      if (resp_status(response) == 200) {
+        print(str_glue("Successfully converted the XML files for ID: {file_id}"))
+        json_file_path <- save_json_response(response, file_id, output_dir)
+        print(str_glue("Saved JSON response for ID: {file_id} to {json_file_path}"))
+      } else {
+        print(str_glue("Failed to convert the XML files for ID: {file_id}\nStatus code: {resp_status(response)}"))
+        print(str_glue("Response content: {resp_body_string(response)}"))
+      }
+    }, error = function(e) {
+      print(str_glue("Error during the request for ID {file_id}: {e$message}"))
+    })
+  }
+  print("File processing complete.")
+}
+
+# start the file processing
+process_files(data_dir = ecr_data_directory, output_dir = fhir_bundle_directory, api_url = convert_to_fhir)

--- a/ecr-parser/scripts/02-convert-to-flat-file.R
+++ b/ecr-parser/scripts/02-convert-to-flat-file.R
@@ -1,0 +1,163 @@
+library(renv)
+renv::load()
+
+library(fs)
+library(httr2)
+library(jsonlite)
+library(tidyverse)
+
+message_parser <- "http://localhost:8085"
+health_check <- str_glue("{message_parser}/")
+parsing_schema <- str_glue("{message_parser}/schemas")
+message_parser <- str_glue("{message_parser}/parse_message")
+
+# check the health of the fhir converter
+check_health <- function(endpoint_url) {
+  resp <- request(endpoint_url) |>
+    req_perform() |>
+    resp_body_json()
+  
+  if (resp$status == "OK") {
+    print("Message Parser is up and running.")
+  } else {
+    print("Message Parser is not running.")
+  }
+}
+
+check_health(health_check)
+
+# read in the parsing schema
+print("Reading the parsing schema from 'config/ecr-parsing-schema.json'...")
+ecr_parsing_schema <- read_json("config/ecr-parsing-schema.json")
+print("Parsing schema loaded successfully.")
+
+# put the parsing schema in the container to use
+print("Uploading the parsing schema to the Message Parser...")
+request(parsing_schema) |>
+  req_url_path_append("/ecr-parsing-schema.json") |>
+  req_method("PUT") |>
+    req_headers(
+    "Content-Type" = "application/json"
+  ) |>
+  req_body_json(data = list(
+    parsing_schema = ecr_parsing_schema,
+    overwrite = TRUE
+  )) |>
+  req_perform()
+print("Parsing schema uploaded successfully.")
+
+# extract the fhir bundle from the fhir converter's response
+extract_fhir_bundle <- function(file_path) {
+  print(str_glue("Extracting FHIR bundle from: {file_path}"))
+  fromJSON(file_path) |>
+    pluck("response", "FhirResource")
+}
+
+replace_null_and_unlist <- function(resp_list) {
+  replaced <- map(resp_list, ~ if (is.null(.x)) NA_character_ else .x)
+  result <- unlist(replaced)
+  return(result)
+}
+
+# send the request to the message parser
+send_request <- function(fhir_bundle) {
+  print("Sending FHIR bundle to Message Parser...")
+  response <- request(message_parser) %>%
+    req_body_json(list(
+      message_format = "fhir",
+      message_type = "ecr",
+      parsing_schema_name = "ecr-parsing-schema.json",
+      message = fhir_bundle
+    )) |>
+    req_perform()
+  print("Received response from Message Parser.")
+  
+  return(resp_body_json(response))
+}
+
+# function to process response and extract data into a dataframe
+process_response <- function(response) {
+  print("Processing the response...")
+  demographics_list <- discard(response$parsed_values, names(response$parsed_values) %in% c("labs", "active_problems"))
+  labs_list <- response$parsed_values |> pluck("labs")
+  active_problems_list <- response$parsed_values |> pluck("active_problems")
+  
+  demographics_df <- demographics_list %>%
+    replace_null_and_unlist() %>%
+    enframe() %>%
+    pivot_wider(names_from = name, values_from = value)
+  
+  if (!is.null(labs_list)) {
+    labs_df <- labs_list |>
+      map_dfr(~ replace_null_and_unlist(.x) |>
+                enframe() |>
+                pivot_wider(names_from = name, values_from = value))
+    
+    labs_df <- bind_cols(
+      demographics_df |> select(patient_id, eicr_id, eicr_set_id, eicr_version_number, authoring_datetime),
+      labs_df
+    )
+  } else {
+    labs_df <- tibble()
+  }
+  
+  if (!is.null(active_problems_list)) {
+    active_problems_df <- active_problems_list |>
+      map_dfr(~ replace_null_and_unlist(.x) |>
+                enframe() |>
+                pivot_wider(names_from = name, values_from = value))
+    
+    active_problems_df <- bind_cols(
+      demographics_df |> select(patient_id, eicr_id, eicr_set_id, eicr_version_number, authoring_datetime),
+      active_problems_df
+    )
+  } else {
+    active_problems_df <- tibble()
+  }
+  
+  print("Response processed successfully.")
+  list(demographics = demographics_df, active_problems = active_problems_df, labs = labs_df)
+}
+
+# get list of fhir bundles to parse
+print("Listing FHIR bundles in 'data/fhir-conversion' directory...")
+files <- dir_ls("data/fhir-conversion", glob = "*.json")
+
+# map over the files to get the data
+results <- map(files, ~ {
+  print(str_glue("Processing file: {.x}"))
+  fhir_bundle <- extract_fhir_bundle(.x)
+  response <- send_request(fhir_bundle)
+  process_response(response)
+})
+
+# combine demographics and write to csv
+print("Combining demographics data...")
+demographics_all <- bind_rows(map(results, "demographics"))
+demographics_output <- str_glue("data/flat-ecr/demographics-{Sys.Date()}.csv")
+write_csv(demographics_all, demographics_output)
+print(str_glue("Demographics data saved to: {demographics_output}"))
+
+# combine and write active_problems to csv if there is data
+print("Combining active problems data...")
+active_problems_all <- bind_rows(map(results, "active_problems"), .id = NULL)
+if (nrow(active_problems_all) > 0) {
+  active_problems_output <- str_glue("data/flat-ecr/active-problems-{Sys.Date()}.csv")
+  write_csv(active_problems_all, active_problems_output)
+  print(str_glue("Active problems data saved to: {active_problems_output}"))
+} else {
+  print("No active problems data to save.")
+}
+
+# combine and write labs to csv if there is data
+print("Combining labs data...")
+labs_all <- bind_rows(map(results, "labs"), .id = NULL)
+if (nrow(labs_all) > 0) {
+  labs_output <- str_glue("data/flat-ecr/labs-{Sys.Date()}.csv")
+  write_csv(labs_all, labs_output)
+  print(str_glue("Labs data saved to: {labs_output}"))
+} else {
+  print("No labs data to save.")
+}
+
+print("Script execution completed.")

--- a/ecr-parser/scripts/README.md
+++ b/ecr-parser/scripts/README.md
@@ -1,0 +1,28 @@
+# `Rscript` versions of the Quarto Notebooks
+
+> [!IMPORTANT]
+> It is important to run these R scripts in your terminal using the `Rscript` command at the `ecr-parser` directory. **NOT** at `ecr-parser/scripts/` directory. This is because the file paths are hard coded to work in this way.
+
+## Prerequisites
+
+The services need to be up and running so before you try to run the R scripts, you'll need to start the services with Docker compose:
+
+```bash
+docker compose up -d
+```
+
+## Running the scripts
+
+This will do everything that you can run interactively in the Quarto Notebook in a single command. This is an example of how you can use the Quarto Notebooks as a way to test how to interact with the APIs to solidify your ideal workflow and then using the `Rscript` command to run it on some frequency that works for your needs.
+
+### Convert to FHIR
+
+```bash
+Rscript scripts/01-convert-to-fhir.R
+```
+
+### Convert to flat file (`*.csv`)
+
+```bash
+Rscript scripts/02-convert-to-flat-file.R
+```


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adding a `scripts/` directory so that a user can run the same scripts in a non-interactive way. An example of how they'd use the notebooks to identify their workflow and automate it with a script.

## Related Issue

Fixes:

- #7 

## Additional Information

Anything else the review team should know?

## Checklist

- [x] Container build and run locally
- [x] Runs locally and produces the correct outputs

[//]: # "PR title: Remember to name your PR descriptively!"
